### PR TITLE
Added a filter to output perfectly mapping reads only (soft-clipping ok)

### DIFF
--- a/cmd/filter.go
+++ b/cmd/filter.go
@@ -121,6 +121,7 @@ const FilterHelp = "Filter parameters:\n" +
 	"[--replace-reference-sequences sam-file]\n" +
 	"[--filter-unmapped-reads]\n" +
 	"[--filter-unmapped-reads-strict]\n" +
+	"[--output-exact-mapping-reads]\n" +
 	"[--replace-read-group read-group-string]\n" +
 	"[--mark-duplicates]\n" +
 	"[--remove-duplicates]\n" +
@@ -135,6 +136,7 @@ func Filter() error {
 	var (
 		replaceReferenceSequences                                     string
 		filterUnmappedReads, filterUnmappedReadsStrict                bool
+		outputExactMappingReads					      bool
 		replaceReadGroup                                              string
 		markDuplicates, markDuplicatesDeterministic, removeDuplicates bool
 		sortingOrder                                                  string
@@ -151,6 +153,7 @@ func Filter() error {
 	flags.StringVar(&replaceReferenceSequences, "replace-reference-sequences", "", "replace the existing header by a new one")
 	flags.BoolVar(&filterUnmappedReads, "filter-unmapped-reads", false, "remove all unmapped alignments")
 	flags.BoolVar(&filterUnmappedReadsStrict, "filter-unmapped-reads-strict", false, "remove all unmapped alignments, taking also POS and RNAME into account")
+	flags.BoolVar(&outputExactMappingReads, "output-exact-mapping-reads", false, "output only exact mapping reads (soft-clipping allowed)")
 	flags.StringVar(&replaceReadGroup, "replace-read-group", "", "add or replace alignment read groups")
 	flags.BoolVar(&markDuplicates, "mark-duplicates", false, "mark duplicates")
 	flags.BoolVar(&markDuplicatesDeterministic, "mark-duplicates-deterministic", false, "mark duplicates deterministically")
@@ -233,6 +236,11 @@ func Filter() error {
 	} else if filterUnmappedReads {
 		filters = append(filters, sam.FilterUnmappedReads)
 		fmt.Fprint(&command, " --filter-unmapped-reads")
+	}
+
+	if outputExactMappingReads {
+		filters = append(filters, sam.OutputExactMappingReads)
+		fmt.Fprint(&command, " --output-exact-mapping-reads")
 	}
 
 	if renameChromosomes {

--- a/sam/simple-filters.go
+++ b/sam/simple-filters.go
@@ -3,6 +3,7 @@ package sam
 import (
 	"math/rand"
 	"strconv"
+	"strings"
 
 	"github.com/exascience/elprep/utils"
 )
@@ -60,6 +61,10 @@ func FilterUnmappedReadsStrict(_ *Header) AlignmentFilter {
 	return func(aln *Alignment) bool {
 		return ((aln.FLAG & Unmapped) == 0) && (aln.POS != 0) && (aln.RNAME != "*")
 	}
+}
+
+func OutputExactMappingReads(_ *Header) AlignmentFilter {
+	return func(aln *Alignment) bool { return !strings.ContainsAny(aln.CIGAR, "IDNHPX=") }
 }
 
 func FilterDuplicateReads(_ *Header) AlignmentFilter {


### PR DESCRIPTION
The following option was added : 

`--output-exact-mapping-reads`

It calls a new filter named `OutputExactMappingReads` which checks the CIGAR string. In the CIGAR string, only matching bases ['M'] and soft-clipped bases are allowed ['S']. More precisely, this is achieved by forbidding all other characters (any in ['IDNHPX=']).